### PR TITLE
Make new options and target framework accessible to nuget consumers

### DIFF
--- a/Project2015To2017.Console/Options.cs
+++ b/Project2015To2017.Console/Options.cs
@@ -1,13 +1,9 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using CommandLine;
-using Project2015To2017.Definition;
-using Project2015To2017.Transforms;
 
 namespace Project2015To2017.Console
 {
-	public class Options: ITransformation
+	public class Options
 	{
 		[Value(0)]
 		public IEnumerable<string> Files { get; set; }
@@ -24,14 +20,6 @@ namespace Project2015To2017.Console
 		[Option('t', "target-frameworks", Separator = ';', HelpText = "Specific target frameworks")]
 		public IEnumerable<string> TargetFrameworks { get; set; }
 
-		public void Transform(Project definition, IProgress<string> progress)
-		{
-			if (definition == null)
-				return;
-
-			definition.GenerateAssemblyInfo = !AssemblyInfo;
-			
-			progress?.Report("Options applied");
-		}
+		public ConversionOptions ConversionOptions => new ConversionOptions {KeepAssemblyInfo = AssemblyInfo};
 	}
 }

--- a/Project2015To2017.Console/Options.cs
+++ b/Project2015To2017.Console/Options.cs
@@ -18,7 +18,7 @@ namespace Project2015To2017.Console
 		[Option('n', "no-backup", Default = false, HelpText = "Will not create a backup folder")]
 		public bool NoBackup { get; set; } = false;
 
-		[Option('a', "assembly-info", Default = false, HelpText = "Keep Assemnly Info in a file")]
+		[Option('a', "assembly-info", Default = false, HelpText = "Keep Assembly Info in a file")]
 		public bool AssemblyInfo { get; set; } = false;
 
 		[Option('t', "target-frameworks", Separator = ';', HelpText = "Specific target frameworks")]

--- a/Project2015To2017.Console/Options.cs
+++ b/Project2015To2017.Console/Options.cs
@@ -30,10 +30,7 @@ namespace Project2015To2017.Console
 				return;
 
 			definition.GenerateAssemblyInfo = !AssemblyInfo;
-			if (null != TargetFrameworks && TargetFrameworks.Any())
-			{
-				definition.TargetFrameworks = TargetFrameworks.ToList();
-			}
+			
 			progress?.Report("Options applied");
 		}
 	}

--- a/Project2015To2017.Console/Program.cs
+++ b/Project2015To2017.Console/Program.cs
@@ -26,17 +26,16 @@ namespace Project2015To2017.Console
 
 			var convertedProjects = new List<Project>();
 
-			//apply some optional pre-transforms
+			//apply an optional pre-transform to change the target framework
 			var preTransforms = new List<ITransformation>
 			{
-				new TargetFrameworkTransformation(options.TargetFrameworks.ToList().AsReadOnly()),
-				options
+				new TargetFrameworkTransformation(options.TargetFrameworks.ToList().AsReadOnly())
 			};
 
 			foreach (var file in options.Files)
 			{
 				var projects = ProjectConverter
-					.Convert(file, preTransforms, new List<ITransformation>(), progress)
+					.Convert(file, options.ConversionOptions, preTransforms, new List<ITransformation>(), progress)
 					.Where(x => x != null)
 					.ToList();
 				convertedProjects.AddRange(projects);

--- a/Project2015To2017.Console/Program.cs
+++ b/Project2015To2017.Console/Program.cs
@@ -25,9 +25,15 @@ namespace Project2015To2017.Console
 #endif
 
 			var convertedProjects = new List<Project>();
-			//apply options as an PreTransform
-			var preTransforms = new List<ITransformation> { options };
-			foreach (string file in options.Files)
+
+			//apply some optional pre-transforms
+			var preTransforms = new List<ITransformation>
+			{
+				new TargetFrameworkTransformation(options.TargetFrameworks.ToList().AsReadOnly()),
+				options
+			};
+
+			foreach (var file in options.Files)
 			{
 				var projects = ProjectConverter
 					.Convert(file, preTransforms, new List<ITransformation>(), progress)

--- a/Project2015To2017/ConversionOptions.cs
+++ b/Project2015To2017/ConversionOptions.cs
@@ -1,0 +1,11 @@
+namespace Project2015To2017
+{
+    public class ConversionOptions
+    {
+	    /// <summary>
+	    /// Whether to keep the AssemblyInfo.cs file, or to
+	    /// move the attributes into the project file
+	    /// </summary>
+	    public bool KeepAssemblyInfo { get; set; } = false;
+    }
+}

--- a/Project2015To2017/Definition/Project.cs
+++ b/Project2015To2017/Definition/Project.cs
@@ -64,8 +64,7 @@ namespace Project2015To2017.Definition
 		}
 
 		public FileInfo PackagesConfigFile { get; set; }
-
-		public bool GenerateAssemblyInfo { get; set; } = true;
+		
 		public IReadOnlyList<XElement> AssemblyAttributeProperties { get; set; } = Array.Empty<XElement>();
 	}
 }

--- a/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
@@ -8,6 +8,8 @@ namespace Project2015To2017.Transforms
 {
 	public class AssemblyAttributeTransformation : ITransformation
 	{
+		public bool KeepAssemblyInfoFile { get; set; }
+
 		public void Transform(Project definition, IProgress<string> progress)
 		{
 			if (definition.AssemblyAttributes == null)
@@ -15,7 +17,7 @@ namespace Project2015To2017.Transforms
 				return;
 			}
 
-			if (definition.GenerateAssemblyInfo)
+			if (!KeepAssemblyInfoFile)
 			{
 				definition.AssemblyAttributeProperties = definition.AssemblyAttributeProperties
 					.Concat(AssemblyAttributeNodes(definition.AssemblyAttributes, definition.PackageConfiguration, progress))

--- a/Project2015To2017/Transforms/TargetFrameworkTransformation.cs
+++ b/Project2015To2017/Transforms/TargetFrameworkTransformation.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Project2015To2017.Definition;
+
+namespace Project2015To2017.Transforms
+{
+    public sealed class TargetFrameworkTransformation : ITransformation
+	{
+		public TargetFrameworkTransformation(IReadOnlyList<string> targetFrameworks)
+		{
+			TargetFrameworks = targetFrameworks;
+		}
+
+		public void Transform(Project definition, IProgress<string> progress)
+		{
+			if (null != TargetFrameworks && TargetFrameworks.Any())
+			{
+				definition.TargetFrameworks = TargetFrameworks;
+			}
+		}
+
+		public IReadOnlyList<string> TargetFrameworks { get; }
+	}
+}

--- a/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
@@ -55,13 +55,15 @@ namespace Project2015To2017Tests
 		{
 			var project = new Project
 			{
-				GenerateAssemblyInfo = false,
 				AssemblyAttributes = BaseAssemblyAttributes(),
 				FilePath = new FileInfo("test.cs"),
 				Deletions = new List<FileSystemInfo>()
 			};
 
-			var transform = new AssemblyAttributeTransformation();
+			var transform = new AssemblyAttributeTransformation
+			{
+				KeepAssemblyInfoFile = true
+			};
 			
 			transform.Transform(project, new Progress<string>());
 


### PR DESCRIPTION
I've had a go at what it could look like instead. The new options bit would be a bit simpler if we changed the converter to be non-static. 

I've gone for a non-breaking change instead for now but it leads to lots of overloads which wouldn't be needed if `ConversionOptions` was a property on the converter instead.

@hvanbakel